### PR TITLE
Update promotions.json

### DIFF
--- a/promotions.json
+++ b/promotions.json
@@ -1,10 +1,10 @@
 {
-  "key": "SmartSavingWeek",
-  "start_date": "2025-07-24 9:00:00 EST",
-  "end_date": "2025-07-31 12:00:00 EST",
-  "title": "Gantt. Kanban. Time Tracker. Now at 35% Off!",
+  "key": "AugustSale2025",
+  "start_date": "2025-08-25 08:00:00 EST",
+  "end_date": "2025-08-30 12:00:00 EST",
+  "title": "WP ERP Pro Just Got More Affordable – Up to 35% Off!",
   "description":"",
-  "content": "Get WP Project Manager Pro to boost your team productivity - ends 31st July!",
-  "action_url": "https://wedevs.com/wp-project-manager-pro/pricing/?utm_source=wpdashboard&utm_medium=Notice&utm_campaign=Smart_Saving_Week",
-  "action_title": "Grab the Deal"
+  "content": "Manage your business more efficiently. For a limited time, grab up to 35% OFF all WP ERP Pro plans. Don't wait, the savings disappear soon!",
+  "action_url": "https://wperp.com/pricing/?utm_source=dashboard&utm_medium=banner&utm_campaign=augsales",
+  "action_title": "Grab It Now"
 }

--- a/promotions.json
+++ b/promotions.json
@@ -2,9 +2,9 @@
   "key": "AugustSale2025",
   "start_date": "2025-08-25 08:00:00 EST",
   "end_date": "2025-08-30 12:00:00 EST",
-  "title": "WP ERP Pro Just Got More Affordable – Up to 35% Off!",
+  "title": "Get up to 35% OFF on WP Project Manager Pro!",
   "description":"",
-  "content": "Manage your business more efficiently. For a limited time, grab up to 35% OFF all WP ERP Pro plans. Don't wait, the savings disappear soon!",
-  "action_url": "https://wperp.com/pricing/?utm_source=dashboard&utm_medium=banner&utm_campaign=augsales",
+  "content": "Get up to 35% OFF on WP Project Manager Pro and unlock access to Kanban Board, Gantt Charts, Time Tracker, Invoice Generator, and more! Limited-time offer!",
+  "action_url": "https://wedevs.com/wp-project-manager-pro/pricing/?utm_source=Ad+Roll&utm_medium=Banner&utm_campaign=August+2025",
   "action_title": "Grab It Now"
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated in-app promotion to run Aug 25–30, 2025 with refreshed title: "Get up to 35% OFF on WP Project Manager Pro!"
  - Messaging emphasizes Kanban, Gantt, Time Tracker, Invoice Generator and a limited-time offer.
  - Call-to-action now reads "Grab It Now" and points to the new August campaign link with tracking parameters.
  - Timing and copy updated only; no functional changes to promotion display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->